### PR TITLE
Fix 1px seam that sometimes shows up under header

### DIFF
--- a/src/partials/header.html.ejs
+++ b/src/partials/header.html.ejs
@@ -3,7 +3,7 @@
     <a href="/">dpogue</a>
   </h1>
 
-  <svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" viewBox="2 0 2828 460" preserveAspectRatio="xMidYMax meet" role="presentation">
+  <svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" viewBox="2 0 2828 455" preserveAspectRatio="xMidYMax meet" role="presentation">
     <title><%= site.title %></title>
     <path role="presentation" fill="#615968" d="M902 203c26-10 51-19 66-27 14-9 17-15 20-17 2-2 4 2 7 2s7-3 13-3c5-1 10 2 16 2l16-3c5 0 11 4 18 7l23 4c8 2 14 5 20 8 5 4 8 6 14 7l23 1c10 0 20 2 26 3l13 4h13c5 0 12 2 19 4l22 6 24 3 12 3h10l23 2 32 3 27 4 19 3 14 4 25 3 25 6 28 6 26 1 30 6c13 3 32 4 50 5h49c15 1 28 4 40 6l33 5 34 1 33 3c10 2 17 3 28 2h41c16 2 32 7 43 9 10 1 15-1 22-1l26 3 29 2 40 4c17 2 35 3 57 7 22 3 48 8 65 12s27 6 37 6 20-2 45 1c78 10 155 25 230 46 50 14 112 35 174 55l226 49H902"></path>
     <path role="presentation" fill="#655764" d="M1161 460l-2-184-50-26c-23-14-58-35-90-51s-61-28-79-34c-17-7-24-7-28-8-5-1-7-3-10-5l-8-11-10-13-13-10-8-3-6 3-9 9-16 14c-5 5-7 8-10 9-3 2-6 1-9 0l-10-5c-4-1-7 0-11 2l-14 8c-4 2-5 3-7 1-3-1-6-5-8-9l-6-7-6-1-8 1-10-1c-3-1-4-3-6-7-2-3-4-9-8-12s-9-3-12-4l-8-3-4 2-6-2-5 1-10-4h-9l-7 2c-2 1-4-1-6-4l-6-6c-2-1-3 1-5 1l-4 2c-2 0-5-1-8 1-3 1-6 4-9 7l-7 10c-2 3-4 5-9 7l-43 14-152 46v270"></path>


### PR DESCRIPTION
SVG is scalable, which means it will eventually scale enough to show all your slight pixel misalignment mistakes. Just change the viewBox to trim off the very bottom of the mountain paths rather than hoping they stay perfectly pixel aligned at all screen sizes.