### PR TITLE
Add Apple's AI training to the list of banned bots

### DIFF
--- a/src/assets/robots.txt
+++ b/src/assets/robots.txt
@@ -13,6 +13,9 @@ Disallow: /
 User-agent: Google-Extended
 Disallow: /
 
+User-agent: Applebot-Extended
+Disallow: /
+
 User-agent: GPTBot
 Disallow: /
 


### PR DESCRIPTION
Shame it's too late because they've already used everyone's data for training.